### PR TITLE
issue #143

### DIFF
--- a/src/routers/challenge-list/index.jsx
+++ b/src/routers/challenge-list/index.jsx
@@ -9,7 +9,7 @@ import { FeedbackButton, showMenu } from "@topcoder/micro-frontends-earn-app";
 import actions from "../../actions";
 import * as utils from "../../utils";
 import store from "../../store";
-import { initialChallengeFilter } from "../..//reducers/filter";
+import { initialChallengeFilter } from "../../reducers/filter";
 import _ from "lodash";
 
 import "react-date-range/dist/theme/default.css";
@@ -29,10 +29,19 @@ const App = () => {
 
   useEffect(() => {
     if (!location.search) {
-      store.dispatch(actions.challenges.getChallengesInit());
-      store.dispatch(
-        actions.challenges.getChallengesDone(initialChallengeFilter)
-      );
+      const currentFilter = store.getState().filter.challenge;
+      const diff = !_.isEqual(initialChallengeFilter, currentFilter);
+
+      if (diff) {
+        const params = utils.challenge.createChallengeParams(currentFilter);
+        utils.url.updateQuery(params, true);
+      } else {
+        store.dispatch(actions.challenges.getChallengesInit());
+        store.dispatch(
+          actions.challenges.getChallengesDone(currentFilter)
+        );
+      }
+
       return;
     }
 

--- a/src/utils/lifeCycle.js
+++ b/src/utils/lifeCycle.js
@@ -5,19 +5,23 @@ import * as utils from "../utils";
 export default function appInit() {
   let initialQuery;
   let urlPath;
+  let firstMounted = true;
 
   function bootstrap() {
     return Promise.resolve().then(() => {
       initialQuery = window.location.search;
-      urlPath = window.location.pathname;
+      urlPath = utils.url.removeTrailingSlash(window.location.pathname);
     });
   }
 
   function mount() {
-    if (initialQuery) {
-      const params = utils.url.parseUrlQuery(initialQuery);
-      const filter = utils.challenge.createChallengeFilter(params);
-      store.dispatch(action.initApp(filter));
+    if (firstMounted) {
+      if (initialQuery && urlPath === '/earn/find/challenges') {
+        const params = utils.url.parseUrlQuery(initialQuery);
+        const filter = utils.challenge.createChallengeFilter(params);
+        store.dispatch(action.initApp(filter));
+      }
+      firstMounted = false;
     }
 
     return Promise.resolve();

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -31,12 +31,16 @@ export function parseUrlQuery(queryString) {
   return qs.parse(queryString, { ignoreQueryPrefix: true });
 }
 
-export function updateQuery(params) {
+export function updateQuery(params, replace = false) {
   const oldQuery = decodeURIComponent(window.location.search);
   let query = buildQueryString(params);
   query = `?${query.substring(1).split("&").sort().join("&")}`;
   if (query !== oldQuery) {
-    window.history.pushState(window.history.state, "", query);
+    if (replace) {
+      window.history.replaceState(window.history.state, "", query);
+    } else {
+      window.history.pushState(window.history.state, "", query);
+    }
   }
 }
 


### PR DESCRIPTION
Fixed: updated query state when challenges-app is remounted

Note:

Case 1 (fixed): https://take.ms/siOo2
Case 2 (external error):  https://take.ms/Ef0hH

For case-2, can it be fixed in gigs-app? When user fast clicks on menu, the two apps are initialized in parallel.


attachments: [2021-11.zip](https://github.com/topcoder-platform/micro-frontends-challenges-app/files/7546020/2021-11.zip)
